### PR TITLE
UM-338: Handle connection timeouts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
-node_modules
+/node_modules/
+/.idea/
+*.iml

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -1,7 +1,7 @@
 var _ = require('lodash'),
     rest = require('restler'),
     Promise = require('bluebird'),
-    Retry = require('./retry')
+    Retry = require('./retry'),
     errors = require('./errors'),
     util = require('./util'),
     log = util.logger(),
@@ -119,19 +119,22 @@ Connection.prototype = {
               } else {
                 defer.reject(data);
               }
+            })
+            .on('timeout', function(ms) {
+              defer.reject(new errors.TimeoutError(ms));
             });
 
             return defer.promise;
         }.bind(this), function(e) {
           log.info('Unable to authenticate: ', e[0]);
         });
-    }
+    };
 
     return this._retry.start(requestFn, this);
   },
 
   getOAuthToken: function(force) {
-    var requestFn;
+    var requestFn, defer;
     force = force || false;
 
     if (force || this._tokenData == null) {

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -69,6 +69,12 @@ function Http4XXError(msg) {
 }
 util.inherits(Http4XXError, Error);
 
+function TimeoutError(timeout) {
+  Error.call(this, 'Timed out after ' + timeout + ' ms.');
+}
+util.inherits(TimeoutError, Error);
+
+
 function hasMarketoCode(err, code) {
   return isMarketoError(err) &&
          !!_.find(err.errors, {code: code});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-marketo",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "marketo rest client",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Restler emits a `timeout` event that's not being handled, so the promise is neither resolved nor rejected. I suspect this is the root cause of the marketo integration getting into a state where the SQS queue is not being checked.

cc @mirceal @peaches 