### PR TITLE
Add mergeLead method

### DIFF
--- a/lib/api/lead.js
+++ b/lib/api/lead.js
@@ -65,6 +65,17 @@ Lead.prototype = {
   partitions: function() {
     var path = util.createPath('leads', 'partitions.json');
     return this._connection.get(path);
+  },
+
+  mergeLead: function(winningLead, losingLeads, options) {
+    if (!_.isArray(losingLeads) && !_.isEmpty(losingLeads)) {
+      var msg = 'input must be an array of lead ids';
+      log.error(msg);
+      return Promise.reject(msg);
+    }
+
+    var path = util.createPath('leads', winningLead, 'merge.json');
+    return this._connection.postJson(path, {data: options}, {query: {leadIds: losingLeads.join()}});
   }
 };
 


### PR DESCRIPTION
Handle the REST API method to merge two leads, with an optional mergeInCRM parameter.