### PR TITLE
Added error handling for OAuth

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -149,6 +149,8 @@ Connection.prototype = {
           }.bind(this))
           .on('fail', function(data, resp) {
             defer.reject(data);
+          }).on('error', function(err){
+            defer.reject(err);
           });
         return defer.promise;
       };


### PR DESCRIPTION
When an invalid rest URL is passed to the `getOAuthToken` method it stops responding since the error isn't being caught or handled. 